### PR TITLE
[bugfix] Encode payload before transmitting

### DIFF
--- a/api_examples/example.py
+++ b/api_examples/example.py
@@ -2,6 +2,7 @@
 # package (http://docs.python-requests.org/en/master/)
 
 import requests
+import base64
 
 API_ENDPOINT = "http://localhost/api/"
 
@@ -20,6 +21,9 @@ def main():
         exit(1)
     data = r.json()
     # data = {"zipFile": "...", "process": "...", "format": "..."}
+
+    # download with a single request (PING-PONG)
+    # open(data["zipFile"] + ".xlsx", 'wb').write(base64.b64decode(data["process"]))
 
     # download the converted data set
     r = requests.get(API_ENDPOINT + "result/" + data["zipFile"], stream=True)

--- a/src/main/kotlin/app/model/Cache.kt
+++ b/src/main/kotlin/app/model/Cache.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
+import java.util.Base64
 
 class Cache(private val dir: File) {
 
@@ -69,8 +70,7 @@ class Cache(private val dir: File) {
             ZipFile(zipFile).use { zip ->
                 val e = findEntry(id, zip) ?: return ""
                 zip.getInputStream(e).buffered().use { stream ->
-                    return String(stream.readBytes(),
-                            Charset.forName("utf-8"))
+                    return String(Base64.getEncoder().encode(stream.readBytes()))
                 }
             }
         } catch (e: Exception) {


### PR DESCRIPTION
During the first request:

The raw bytes of the process content where encoded as UTF-8 and sent to the wire as plaintext which cause some disforms some bytes and results in a corrupted file.
This PR fixes that by encoding the payload at the server send (in Base64) and decode it at the client side.

I have tested it on my end and works as expected with a single request.
I don't think this would break anything.