### PR TITLE
keep server.jar inside repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ config.ini
 
 ui/build/
 ui/node_modules/
-target/
+target/*
+!target/server.jar
 
 .settings/
 .project


### PR DESCRIPTION
Makes it easier to build a container from repository.

It would be worth it to enable gitLFS just for that jar.